### PR TITLE
test packages removed from build dependencies

### DIFF
--- a/lisper.cabal
+++ b/lisper.cabal
@@ -30,16 +30,13 @@ library
 
   default-extensions:  OverloadedStrings
   other-extensions:    OverloadedStrings, PatternSynonyms
-  build-depends:       HUnit,
-                       base,
+  build-depends:       base,
                        bytestring,
                        directory,
                        haskeline,
                        mtl,
                        parsec,
-                       process,
-                       tasty,
-                       tasty-hunit
+                       process
   ghc-options:         -Wall -fwarn-tabs
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Hi,
This PR removes test packages such as `HUnit`, `tasty`,`tasty-hunit` from build dependencies as they are not required. Build and tests run properly using resolver as `lts-13.19`.

_Please let me know if I need to make any further modifications or changes._